### PR TITLE
Bump rust ver

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,6 @@ jobs:
       run: rustup install nightly
     - name: Run check
       run: |
-        cargo check --all
         cargo fmt --all -- --check
         cargo clippy --all
         ./build_doc.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,12 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ github.event.repository.name }}-${{ runner.os }}-cargo-check-v3
+    - name: Install latest stable cargo
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
     - name: Install cargo nightly
       run: rustup install nightly
     - name: Run check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-io-utility"
 version = "0.6.6"
-edition = "2018"
+edition = "2021"
 
 authors = ["Jiahao XU <Jiahao_XU@outlook.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tokio-io-utility"
 version = "0.6.6"
 edition = "2021"
+rust-version = "1.60"
 
 authors = ["Jiahao XU <Jiahao_XU@outlook.com>"]
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,5 +1,17 @@
 #!/bin/bash -ex
 
+arch=$(uname -m)
+if [ "$arch" = "arm64" ]; then
+    arch=aarch64
+fi
+
+os=unknown-linux-gnu
+if uname -v | grep -s Darwin >/dev/null; then
+    os=apple-darwin
+fi
+
+target="$arch-$os"
+
 rep=$(seq 1 10)
 
 for _ in $rep; do
@@ -21,7 +33,7 @@ done
 #for _ in $rep; do
 #    cargo +nightly test \
 #        -Z build-std \
-#        --target $(uname -m)-unknown-linux-gnu \
+#        --target "$target" \
 #        --all-features queue::tests::test_par -- --nocapture
 #done
 
@@ -30,10 +42,10 @@ export MIRIFLAGS="-Zmiri-disable-isolation"
 
 cargo +nightly miri test \
     -Z build-std \
-    --target $(uname -m)-unknown-linux-gnu \
+    --target "$target" \
     --all-features io_slice_ext -- --nocapture
 
 exec cargo +nightly miri test \
     -Z build-std \
-    --target $(uname -m)-unknown-linux-gnu \
+    --target "$target" \
     --all-features queue::tests::test_seq -- --nocapture


### PR DESCRIPTION
Rust 1.60.0 provides new function [`Vec::spare_capacity_mut`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.spare_capacity_mut), which reduces amount of `unsafe` code required for `ReadToVecFuture` impl.