### PR TITLE
Refactor: Extract `ReusableIoSlices` and `init_maybeuninit_io_slices_mut`(unused)

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -23,6 +23,7 @@ cargo +nightly test --all-features async_read_utility -- --nocapture
 cargo +nightly test --all-features async_write_utility -- --nocapture
 cargo +nightly test --all-features io_slice_ext -- --nocapture
 cargo +nightly test --all-features reusable_io_slices -- --nocapture
+cargo +nightly test --all-features init_maybeuninit_io_slice -- --nocapture
 
 for _ in $rep; do
     cargo +nightly test --all-features queue -- --nocapture
@@ -50,6 +51,11 @@ cargo +nightly miri test \
     -Z build-std \
     --target "$target" \
     --all-features reusable_io_slices -- --nocapture
+
+cargo +nightly miri test \
+    -Z build-std \
+    --target "$target" \
+    --all-features init_maybeuninit_io_slice -- --nocapture
 
 exec cargo +nightly miri test \
     -Z build-std \

--- a/run_test.sh
+++ b/run_test.sh
@@ -22,6 +22,7 @@ export RUSTFLAGS='-Zsanitizer=address'
 cargo +nightly test --all-features async_read_utility -- --nocapture
 cargo +nightly test --all-features async_write_utility -- --nocapture
 cargo +nightly test --all-features io_slice_ext -- --nocapture
+cargo +nightly test --all-features reusable_io_slices -- --nocapture
 
 for _ in $rep; do
     cargo +nightly test --all-features queue -- --nocapture
@@ -44,6 +45,11 @@ cargo +nightly miri test \
     -Z build-std \
     --target "$target" \
     --all-features io_slice_ext -- --nocapture
+
+cargo +nightly miri test \
+    -Z build-std \
+    --target "$target" \
+    --all-features reusable_io_slices -- --nocapture
 
 exec cargo +nightly miri test \
     -Z build-std \

--- a/src/init_maybeuninit_io_slice.rs
+++ b/src/init_maybeuninit_io_slice.rs
@@ -1,0 +1,59 @@
+use std::{
+    io::IoSlice,
+    iter::{IntoIterator, Iterator},
+    mem::MaybeUninit,
+};
+
+pub fn init_maybeuninit_io_slices_mut<'a, 'io_slice, Iterable>(
+    uninit_io_slices: &'a mut [MaybeUninit<IoSlice<'io_slice>>],
+    iterable: Iterable,
+) -> &'a mut [IoSlice<'io_slice>]
+where
+    Iterable: IntoIterator<Item = IoSlice<'io_slice>>,
+{
+    let mut cnt = 0;
+
+    uninit_io_slices
+        .iter_mut()
+        .zip(iterable)
+        .for_each(|(uninit_io_slice, io_slice)| {
+            uninit_io_slice.write(io_slice);
+            cnt += 1;
+        });
+
+    // Safety:
+    //
+    // uninit_io_slices[..cnt] is initialized using iterable.
+    unsafe { &mut *((&mut uninit_io_slices[..cnt]) as *mut _ as *mut [IoSlice<'io_slice>]) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::IoSliceExt;
+
+    #[test]
+    fn test() {
+        let mut uninit_io_slices = [MaybeUninit::<IoSlice<'_>>::uninit(); 5];
+        let io_slices = [
+            IoSlice::new(b"1023x"),
+            IoSlice::new(b"1qwe"),
+            IoSlice::new(b"''weqdq"),
+            IoSlice::new(b"jiasodjx"),
+            IoSlice::new(b"aqw34f"),
+        ];
+        assert_io_slices_eq(
+            init_maybeuninit_io_slices_mut(&mut uninit_io_slices, io_slices),
+            &io_slices,
+        );
+    }
+
+    fn assert_io_slices_eq(x: &[IoSlice<'_>], y: &[IoSlice<'_>]) {
+        assert_eq!(x.len(), y.len());
+
+        let x: Vec<&[u8]> = x.iter().copied().map(IoSliceExt::into_inner).collect();
+        let y: Vec<&[u8]> = y.iter().copied().map(IoSliceExt::into_inner).collect();
+
+        assert_eq!(x, y);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ macro_rules! ready {
 mod async_read_utility;
 mod async_write_utility;
 mod io_slice_ext;
+mod reusable_io_slices;
 
 #[cfg(feature = "mpsc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mpsc")))]
@@ -24,3 +25,4 @@ pub mod queue;
 pub use async_read_utility::*;
 pub use async_write_utility::write_vectored_all;
 pub use io_slice_ext::{IoSliceExt, IoSliceMutExt};
+pub use reusable_io_slices::ReusableIoSlices;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ macro_rules! ready {
 
 mod async_read_utility;
 mod async_write_utility;
+mod init_maybeuninit_io_slice;
 mod io_slice_ext;
 mod reusable_io_slices;
 
@@ -24,5 +25,6 @@ pub mod queue;
 
 pub use async_read_utility::*;
 pub use async_write_utility::write_vectored_all;
+pub use init_maybeuninit_io_slice::init_maybeuninit_io_slices_mut;
 pub use io_slice_ext::{IoSliceExt, IoSliceMutExt};
 pub use reusable_io_slices::ReusableIoSlices;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -22,9 +22,6 @@ pub struct MpScBytesQueue {
     io_slice_buf: AsyncMutex<ReusableIoSlices>,
 }
 
-unsafe impl Send for MpScBytesQueue {}
-unsafe impl Sync for MpScBytesQueue {}
-
 impl MpScBytesQueue {
     /// * `cap` - This is the maximum amount of `io_slice`s that `Buffers::get_io_slices()`
     /// can return.
@@ -182,8 +179,6 @@ pub struct Buffers<'a> {
     io_slice_start: usize,
     io_slice_end: usize,
 }
-
-unsafe impl Send for Buffers<'_> {}
 
 impl<'a> Buffers<'a> {
     /// Return `IoSlice`s that every one of them is non-empty.

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -86,13 +86,8 @@ impl MpScBytesQueue {
 
         let len = bytes_queue_guard.len();
 
-        let io_slices_buf = io_slices_guard.get_mut();
-
-        let io_slice_buf_len = io_slices_buf.len();
-        let io_slice_buf_ptr = io_slices_buf.as_mut_ptr() as *mut u8 as *mut MaybeUninit<IoSlice>;
-
-        // safety: This conversion reuses the memory of `io_slice_buf`.
-        let uninit_slices = unsafe { from_raw_parts_mut(io_slice_buf_ptr, io_slice_buf_len) };
+        let uninit_slices = io_slices_guard.get_mut();
+        let io_slice_buf_len = uninit_slices.len();
 
         bytes_queue_guard
             .iter()

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -3,9 +3,8 @@ use std::{
     collections::VecDeque,
     io::IoSlice,
     iter::{ExactSizeIterator, Iterator},
-    mem::{transmute, MaybeUninit},
+    mem::MaybeUninit,
     num::NonZeroUsize,
-    slice::from_raw_parts_mut,
 };
 
 pub use std::collections::vec_deque::Drain;
@@ -189,12 +188,11 @@ unsafe impl Send for Buffers<'_> {}
 impl<'a> Buffers<'a> {
     /// Return `IoSlice`s that every one of them is non-empty.
     pub fn get_io_slices<'this>(&'this self) -> &[IoSlice<'this>] {
-        let pointer = (self.io_slices_guard.get()) as *const [MaybeUninit<IoSlice<'this>>];
-        let uninit_slices: &[MaybeUninit<IoSlice>] = unsafe { &*pointer };
+        let uninit_slices = &self.io_slices_guard.get()[self.io_slice_start..self.io_slice_end];
 
         // Safety: The io_slices are valid as long as the `MutexGuard` since there can only be one
         // consumer.
-        unsafe { transmute(&uninit_slices[self.io_slice_start..self.io_slice_end]) }
+        unsafe { &*(uninit_slices as *const _ as *const [IoSlice<'_>]) }
     }
 
     /// Return `true` if no `io_slices` is left.
@@ -223,17 +221,14 @@ impl<'a> Buffers<'a> {
 
         let queue = self.queue;
 
-        let io_slices_buf = self.io_slices_guard.get_mut();
+        let mut bufs: &mut [IoSlice<'_>] = {
+            let uninit_slices =
+                &mut self.io_slices_guard.get_mut()[self.io_slice_start..self.io_slice_end];
 
-        let io_slice_buf_len = io_slices_buf.len();
-        let io_slice_buf_ptr = io_slices_buf.as_mut_ptr() as *mut u8 as *mut MaybeUninit<IoSlice>;
-
-        // Safety: The io_slices are valid as long as the `MutexGuard` since there can only be one
-        // consumer.
-        let uninit_slices = unsafe { from_raw_parts_mut(io_slice_buf_ptr, io_slice_buf_len) };
-
-        let mut bufs: &mut [IoSlice] =
-            unsafe { transmute(&mut uninit_slices[self.io_slice_start..self.io_slice_end]) };
+            // Safety: The io_slices are valid as long as the `MutexGuard` since there can only be one
+            // consumer.
+            unsafe { &mut *(uninit_slices as *mut _ as *mut [IoSlice<'_>]) }
+        };
 
         if bufs.is_empty() {
             debug_assert_eq!(self.io_slice_start, self.io_slice_end);

--- a/src/reusable_io_slices.rs
+++ b/src/reusable_io_slices.rs
@@ -40,7 +40,7 @@ impl ReusableIoSlices {
     }
 
     /// Return the underlying io_slices
-    pub fn get(&mut self) -> &mut [MaybeUninit<IoSlice<'_>>] {
+    pub fn get_mut(&mut self) -> &mut [MaybeUninit<IoSlice<'_>>] {
         unsafe {
             from_raw_parts_mut(
                 self.ptr.as_ptr() as *mut MaybeUninit<IoSlice<'_>>,
@@ -52,7 +52,7 @@ impl ReusableIoSlices {
 
 impl Drop for ReusableIoSlices {
     fn drop(&mut self) {
-        let io_slices = self.get() as *mut _;
+        let io_slices = self.get_mut() as *mut _;
         drop(unsafe { Box::from_raw(io_slices) });
     }
 }
@@ -69,7 +69,7 @@ mod tests {
             let cap = NonZeroUsize::new(size).unwrap();
             let mut reusable_io_slices = ReusableIoSlices::new(cap);
 
-            for uninit_io_slice in reusable_io_slices.get() {
+            for uninit_io_slice in reusable_io_slices.get_mut() {
                 uninit_io_slice.write(io_slice);
             }
         }

--- a/src/reusable_io_slices.rs
+++ b/src/reusable_io_slices.rs
@@ -2,6 +2,8 @@ use std::{
     io::IoSlice, mem::MaybeUninit, num::NonZeroUsize, ptr::NonNull, slice::from_raw_parts_mut,
 };
 
+/// [`Box`]ed [`IoSlice`] that can be reused for different io_slices
+/// with different lifetime.
 #[derive(Debug)]
 pub struct ReusableIoSlices {
     ptr: NonNull<()>,
@@ -39,6 +41,7 @@ impl ReusableIoSlices {
         Self { ptr, cap }
     }
 
+    /// Return the underlying io_slices
     pub fn get(&mut self) -> &mut [MaybeUninit<IoSlice<'_>>] {
         // Safety:
         //  - self.ptr.as_ptr() is result of io_slices.as_mut_ptr()

--- a/src/reusable_io_slices.rs
+++ b/src/reusable_io_slices.rs
@@ -1,0 +1,82 @@
+use std::{
+    io::IoSlice, mem::MaybeUninit, num::NonZeroUsize, ptr::NonNull, slice::from_raw_parts_mut,
+};
+
+#[derive(Debug)]
+pub struct ReusableIoSlices {
+    ptr: NonNull<()>,
+    cap: NonZeroUsize,
+}
+
+unsafe impl Send for ReusableIoSlices {}
+unsafe impl Sync for ReusableIoSlices {}
+
+impl ReusableIoSlices {
+    /// Create new [`ReusableIoSlices`].
+    pub fn new(cap: NonZeroUsize) -> Self {
+        let io_slices: Vec<MaybeUninit<IoSlice<'_>>> =
+            (0..cap.get()).map(|_| MaybeUninit::uninit()).collect();
+
+        let io_slices: Box<_> = io_slices.into_boxed_slice();
+
+        let io_slices = Box::into_raw(io_slices);
+
+        // Safety:
+        //
+        // io_slices is result of `Box::into_raw`
+        let io_slices: &mut [MaybeUninit<IoSlice<'_>>] = unsafe { &mut *io_slices };
+
+        let ptr = io_slices.as_mut_ptr();
+
+        // Safety:
+        //
+        // io_slices is a valid allocation, thus slice::as_mut_ptr
+        // must return a non-null pointer
+        let ptr = unsafe { NonNull::new_unchecked(ptr as *mut ()) };
+
+        debug_assert_eq!(io_slices.len(), cap.get());
+
+        Self { ptr, cap }
+    }
+
+    pub fn get(&mut self) -> &mut [MaybeUninit<IoSlice<'_>>] {
+        // Safety:
+        //  - self.ptr.as_ptr() is result of io_slices.as_mut_ptr()
+        //  - self.cap.get() == io_slices.len()
+        unsafe {
+            from_raw_parts_mut(
+                self.ptr.as_ptr() as *mut MaybeUninit<IoSlice<'_>>,
+                self.cap.get(),
+            )
+        }
+    }
+}
+
+impl Drop for ReusableIoSlices {
+    fn drop(&mut self) {
+        let io_slices = self.get() as *mut _;
+        // Safety:
+        //
+        // io_slices is created using `Box::into_raw`.
+        drop(unsafe { Box::from_raw(io_slices) });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reusable_io_slices() {
+        let io_slice = IoSlice::new(b"123exr3x");
+
+        for size in 1..300 {
+            let cap = NonZeroUsize::new(size).unwrap();
+            let mut reusable_io_slices = ReusableIoSlices::new(cap);
+
+            for uninit_io_slice in reusable_io_slices.get() {
+                uninit_io_slice.write(io_slice);
+            }
+        }
+    }
+}

--- a/src/reusable_io_slices.rs
+++ b/src/reusable_io_slices.rs
@@ -3,7 +3,7 @@ use std::{
     mem::{ManuallyDrop, MaybeUninit},
     num::NonZeroUsize,
     ptr::NonNull,
-    slice::from_raw_parts_mut,
+    slice::{from_raw_parts, from_raw_parts_mut},
 };
 
 /// [`Box`]ed [`IoSlice`] that can be reused for different io_slices
@@ -44,6 +44,16 @@ impl ReusableIoSlices {
         unsafe {
             from_raw_parts_mut(
                 self.ptr.as_ptr() as *mut MaybeUninit<IoSlice<'_>>,
+                self.cap.get(),
+            )
+        }
+    }
+
+    /// Return the underlying io_slices
+    pub fn get(&self) -> &[MaybeUninit<IoSlice<'_>>] {
+        unsafe {
+            from_raw_parts(
+                self.ptr.as_ptr() as *const MaybeUninit<IoSlice<'_>>,
                 self.cap.get(),
             )
         }

--- a/src/reusable_io_slices.rs
+++ b/src/reusable_io_slices.rs
@@ -41,9 +41,6 @@ impl ReusableIoSlices {
 
     /// Return the underlying io_slices
     pub fn get(&mut self) -> &mut [MaybeUninit<IoSlice<'_>>] {
-        // Safety:
-        //  - self.ptr.as_ptr() is result of io_slices.as_mut_ptr()
-        //  - self.cap.get() == io_slices.len()
         unsafe {
             from_raw_parts_mut(
                 self.ptr.as_ptr() as *mut MaybeUninit<IoSlice<'_>>,
@@ -56,9 +53,6 @@ impl ReusableIoSlices {
 impl Drop for ReusableIoSlices {
     fn drop(&mut self) {
         let io_slices = self.get() as *mut _;
-        // Safety:
-        //
-        // io_slices is created using `Box::into_raw`.
         drop(unsafe { Box::from_raw(io_slices) });
     }
 }


### PR DESCRIPTION
And refactor mod `queue`, removing all but two `unsafe` blocks for obtaining `& (mut) [IoSlice<'_>]` from `& (mut) [MaybeUninit<IoSlice<'_>>]`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>