### PR TITLE
Fix bug in `read_to_container_rng` when upper bound is unspecified

### DIFF
--- a/src/async_read_utility/inner.rs
+++ b/src/async_read_utility/inner.rs
@@ -199,7 +199,7 @@ where
     let max = match rng.end_bound().cloned() {
         Included(val) => val,
         Excluded(val) => val - 1,
-        Unbounded => container.capacity() - container.len(),
+        Unbounded => min.max(container.capacity() - container.len()),
     };
     container.reserve(max);
 


### PR DESCRIPTION
Fixed #17

make sure the upper bound is always larger than lower bound when it is unspecified.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>